### PR TITLE
Small fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ COPY service /etc/service
 COPY usr/sbin/runit_bootstrap /usr/sbin/runit_bootstrap
 COPY etc/rsyslog.conf /etc/rsyslog.conf
 
+RUN ln -sf /dev/stdout /var/log/mail.log
+
 STOPSIGNAL SIGKILL
 
 ENTRYPOINT ["/usr/sbin/runit_bootstrap"]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # kubernetes-postfix
 
-Scripts, Dockerfile and stuff needed to run Postfix mailserver in Kubernetes. For more information on how to use this repo and it's content see my blog post: [Run a Postfix mailserver with TLS and SPF in Kubernetes - a first try with much space for improvment ;-)](https://www.tauceti.blog/post/run-postfix-in-kubernetes/).
+Scripts, Dockerfile and stuff needed to run Postfix mailserver in Kubernetes. For more information on how to use this repo and it's content see my blog post: [Run a Postfix mail server with TLS and SPF in Kubernetes](https://www.tauceti.blog/posts/run-postfix-in-kubernetes/).


### PR DESCRIPTION
* add softlink `/dev/stdout` -> `/var/log/mail.log` in `Dockerfile`. This is needed to make `kubectl logs ...` work (which means getting the content of `/var/log/mail.log` there)
* fix link in README